### PR TITLE
Fix GC count Bug in handle_transaction_serviced_signal_from_PHY()

### DIFF
--- a/src/ssd/GC_and_WL_Unit_Base.cpp
+++ b/src/ssd/GC_and_WL_Unit_Base.cpp
@@ -61,6 +61,7 @@ namespace SSD_Components
 				{
 					NVM::FlashMemory::Physical_Page_Address gc_wl_candidate_address(transaction->Address);
 					Block_Pool_Slot_Type* block = &pbke->Blocks[transaction->Address.BlockID];
+					Stats::Total_gc_executions++;
 					_my_instance->tsu->Prepare_for_transaction_submit();
 					NVM_Transaction_Flash_ER* gc_wl_erase_tr = new NVM_Transaction_Flash_ER(Transaction_Source_Type::GC_WL, block->Stream_id, gc_wl_candidate_address);
 					if (block->Current_page_write_index - block->Invalid_page_count > 0)//If there are some valid pages in block, then prepare flash transactions for page movement


### PR DESCRIPTION
  The handle_transaction_serviced_signal_from_PHY() in
GC_and_WL_Unit_Base.cpp works on hanging GC request of a Block after
USERIO, MAPPING or CACHE transactions are processed on the block.
However, the function does not add the Stats::Total_gc_executions
counter before submitting erasure command to TSU. This patch fixes
the bug by adding the counter before preparing the ER transaction.
