### PR TITLE
Various bug fixes

### DIFF
--- a/src/host/IO_Flow_Base.cpp
+++ b/src/host/IO_Flow_Base.cpp
@@ -543,15 +543,15 @@ IO_Flow_Base::IO_Flow_Base(const sim_object_id_type &name, uint16_t flow_id, LHA
 		xmlwriter.Write_attribute_string(attr, val);
 
 		attr = "IOPS";
-		val = std::to_string((double)STAT_generated_request_count / (Simulator->Time() / SIM_TIME_TO_SECONDS_COEFF));
+		val = std::to_string((double)STAT_generated_request_count / ((double)Simulator->Time() / SIM_TIME_TO_SECONDS_COEFF));
 		xmlwriter.Write_attribute_string(attr, val);
 
 		attr = "IOPS_Read";
-		val = std::to_string((double)STAT_generated_read_request_count / (Simulator->Time() / SIM_TIME_TO_SECONDS_COEFF));
+		val = std::to_string((double)STAT_generated_read_request_count / ((double)Simulator->Time() / SIM_TIME_TO_SECONDS_COEFF));
 		xmlwriter.Write_attribute_string(attr, val);
 
 		attr = "IOPS_Write";
-		val = std::to_string((double)STAT_generated_write_request_count / (Simulator->Time() / SIM_TIME_TO_SECONDS_COEFF));
+		val = std::to_string((double)STAT_generated_write_request_count / ((double)Simulator->Time() / SIM_TIME_TO_SECONDS_COEFF));
 		xmlwriter.Write_attribute_string(attr, val);
 
 		attr = "Bytes_Transferred";
@@ -567,15 +567,15 @@ IO_Flow_Base::IO_Flow_Base(const sim_object_id_type &name, uint16_t flow_id, LHA
 		xmlwriter.Write_attribute_string(attr, val);
 
 		attr = "Bandwidth";
-		val = std::to_string((double)STAT_transferred_bytes_total / (Simulator->Time() / SIM_TIME_TO_SECONDS_COEFF));
+		val = std::to_string((double)STAT_transferred_bytes_total / ((double)Simulator->Time() / SIM_TIME_TO_SECONDS_COEFF));
 		xmlwriter.Write_attribute_string(attr, val);
 
 		attr = "Bandwidth_Read";
-		val = std::to_string((double)STAT_transferred_bytes_read / (Simulator->Time() / SIM_TIME_TO_SECONDS_COEFF));
+		val = std::to_string((double)STAT_transferred_bytes_read / ((double)Simulator->Time() / SIM_TIME_TO_SECONDS_COEFF));
 		xmlwriter.Write_attribute_string(attr, val);
 
 		attr = "Bandwidth_Write";
-		val = std::to_string((double)STAT_transferred_bytes_write / (Simulator->Time() / SIM_TIME_TO_SECONDS_COEFF));
+		val = std::to_string((double)STAT_transferred_bytes_write / ((double)Simulator->Time() / SIM_TIME_TO_SECONDS_COEFF));
 		xmlwriter.Write_attribute_string(attr, val);
 
 

--- a/src/ssd/Data_Cache_Manager_Flash_Advanced.cpp
+++ b/src/ssd/Data_Cache_Manager_Flash_Advanced.cpp
@@ -85,7 +85,7 @@ namespace SSD_Components
 				break;
 		}
 		
-		delete per_stream_cache;
+		delete[] per_stream_cache;
 		delete[] dram_execution_queue;
 		delete[] waiting_user_requests_queue_for_dram_free_slot;
 		delete[] bloom_filter;

--- a/src/ssd/Data_Cache_Manager_Flash_Simple.cpp
+++ b/src/ssd/Data_Cache_Manager_Flash_Simple.cpp
@@ -96,6 +96,8 @@ namespace SSD_Components
 					if (user_request->Transaction_list.size() > 0) {
 						static_cast<FTL*>(nvm_firmware)->Address_Mapping_Unit->Translate_lpa_to_ppa_and_dispatch(user_request->Transaction_list);
 					}
+
+					return;
 				}
 				default:
 					PRINT_ERROR("The specified caching mode is not not support in simple cache manager!")
@@ -113,6 +115,8 @@ namespace SSD_Components
 					if (user_request->Transaction_list.size() > 0) {
 						waiting_user_requests_queue_for_dram_free_slot[user_request->Stream_id].push_back(user_request);
 					}
+
+					return;
 				}
 				default:
 					PRINT_ERROR("The specified caching mode is not not support in simple cache manager!")

--- a/src/ssd/NVM_PHY_ONFI_NVDDR2.cpp
+++ b/src/ssd/NVM_PHY_ONFI_NVDDR2.cpp
@@ -326,7 +326,9 @@ namespace SSD_Components {
 	{
 		int i = 0;
 		for (auto &address : command->Address) {
-			if (address.PlaneID == read_transaction->Address.PlaneID) {
+			// check if we are not reading a page that has not been written before
+			if (address.PlaneID == read_transaction->Address.PlaneID &&
+				   command->Meta_data[i].LPA != NO_LPA) {
 				read_transaction->LPA = command->Meta_data[i].LPA;
 			}
 			i++;

--- a/src/ssd/Queue_Probe.cpp
+++ b/src/ssd/Queue_Probe.cpp
@@ -171,12 +171,16 @@ namespace SSD_Components
 
 	sim_time_type Queue_Probe::AvgWaitingTime()
 	{
-		return (sim_time_type)((double)totalWaitingTime / (double)(nDepartures * 1000));//convert nano-seconds to micro-seconds
+		if(nDepartures)
+			return (sim_time_type)((double)totalWaitingTime / (double)(nDepartures * 1000));//convert nano-seconds to micro-seconds
+		return 0;
 	}
 
 	sim_time_type Queue_Probe::AvgWaitingTimeEpoch()
 	{
-		return (sim_time_type)((double)totalWaitingTimeEpoch / (double)(nDeparturesEpoch * 1000));
+		if(nDeparturesEpoch)
+			return (sim_time_type)((double)totalWaitingTimeEpoch / (double)(nDeparturesEpoch * 1000));
+		return 0;
 	}
 
 	sim_time_type Queue_Probe::TotalWaitingTime()


### PR DESCRIPTION
## fix wrong average queue waiting time
The value will explode when there is actually no requests destined for that queue.  Should do a sanity check

## cache manager
* The missing return causes the `WRITE_CACHE` switch branch to fall into the default branch, causing an error
* Fix memory leak

## prevent garbage address when reading unwritten page
if the user attempts to read a page that has never been written before, its LPA might be overwritten by NO_LPA.  Check this corner case