### PR TITLE
Fix the program suspend problems.

### DIFF
--- a/src/exec/Device_Parameter_Set.cpp
+++ b/src/exec/Device_Parameter_Set.cpp
@@ -596,7 +596,7 @@ void Device_Parameter_Set::XML_deserialize(rapidxml::xml_node<> *node)
 			} else if (strcmp(param->name(), "Static_Wearleveling_Threshold") == 0) {
 				std::string val = param->value();
 				Static_Wearleveling_Threshold = std::stoul(val);
-			} else if (strcmp(param->name(), "Prefered_suspend_erase_time_for_read") == 0) {
+			} else if (strcmp(param->name(), "Preferred_suspend_erase_time_for_read") == 0) {
 				std::string val = param->value();
 				Preferred_suspend_erase_time_for_read = std::stoull(val);
 			} else if (strcmp(param->name(), "Preferred_suspend_erase_time_for_write") == 0) {

--- a/src/ssd/NVM_PHY_ONFI.h
+++ b/src/ssd/NVM_PHY_ONFI.h
@@ -30,6 +30,7 @@ namespace SSD_Components
 		virtual LPA_type Get_metadata(flash_channel_ID_type channe_id, flash_chip_ID_type chip_id, flash_die_ID_type die_id, flash_plane_ID_type plane_id, flash_block_ID_type block_id, flash_page_ID_type page_id) = 0;//A simplification to decrease the complexity of GC execution! The GC unit may need to know the metadata of a page to decide if a page is valid or invalid. 
 		virtual bool HasSuspendedCommand(NVM::FlashMemory::Flash_Chip* chip) = 0;
 		virtual ChipStatus GetChipStatus(NVM::FlashMemory::Flash_Chip* chip) = 0;
+		virtual bool CheckSuspendLock(NVM::FlashMemory::Flash_Chip* chip) = 0;
 		virtual sim_time_type Expected_finish_time(NVM::FlashMemory::Flash_Chip* chip) = 0;
 		/// Provides communication between controller and NVM chips for a simple read/write/erase command.
 		virtual void Send_command_to_chip(std::list<NVM_Transaction_Flash*>& transactionList) = 0;

--- a/src/ssd/NVM_PHY_ONFI_NVDDR2.h
+++ b/src/ssd/NVM_PHY_ONFI_NVDDR2.h
@@ -77,12 +77,13 @@ namespace SSD_Components
 		sim_time_type Expected_command_exec_finish_time;
 		sim_time_type Last_transfer_finish_time;
 		bool HasSuspend;
+		bool SuspendLock; //void suspend on relate read
 		std::queue<DieBookKeepingEntry*> OngoingDieCMDTransfers;
 		unsigned int WaitingReadTXCount;
 		unsigned int No_of_active_dies;
 
 		void PrepareSuspend() { HasSuspend = true; No_of_active_dies = 0; }
-		void PrepareResume() { HasSuspend = false; }
+		void PrepareResume() { HasSuspend = false; No_of_active_dies++;}
 	};
 
 	class NVM_PHY_ONFI_NVDDR2 : public NVM_PHY_ONFI
@@ -108,6 +109,7 @@ namespace SSD_Components
 		NVM_Transaction_Flash* Is_chip_busy_with_stream(NVM_Transaction_Flash* transaction);
 		bool Is_chip_busy(NVM_Transaction_Flash* transaction);
 		void Change_memory_status_preconditioning(const NVM::NVM_Memory_Address* address, const void* status_info);
+		bool CheckSuspendLock(NVM::FlashMemory::Flash_Chip* chip);
 	private:
 		void transfer_read_data_from_chip(ChipBookKeepingEntry* chipBKE, DieBookKeepingEntry* dieBKE, NVM_Transaction_Flash* tr);
 		void perform_interleaved_cmd_data_transfer(NVM::FlashMemory::Flash_Chip* chip, DieBookKeepingEntry* bookKeepingEntry);

--- a/src/ssd/TSU_Base.cpp
+++ b/src/ssd/TSU_Base.cpp
@@ -7,12 +7,20 @@ namespace SSD_Components
 {
 	TSU_Base* TSU_Base::_my_instance = NULL;
 
-	TSU_Base::TSU_Base(const sim_object_id_type& id, FTL* ftl, NVM_PHY_ONFI_NVDDR2* NVMController, Flash_Scheduling_Type Type,
-		unsigned int ChannelCount, unsigned int chip_no_per_channel, unsigned int DieNoPerChip, unsigned int PlaneNoPerDie,
-		bool EraseSuspensionEnabled, bool ProgramSuspensionEnabled,
+	TSU_Base::TSU_Base(
+		const sim_object_id_type& id, 
+		FTL* ftl, 
+		NVM_PHY_ONFI_NVDDR2* NVMController, 
+		Flash_Scheduling_Type Type,	
+		unsigned int ChannelCount, 
+		unsigned int chip_no_per_channel, 
+		unsigned int DieNoPerChip, 
+		unsigned int PlaneNoPerDie,
 		sim_time_type WriteReasonableSuspensionTimeForRead,
 		sim_time_type EraseReasonableSuspensionTimeForRead,
-		sim_time_type EraseReasonableSuspensionTimeForWrite)
+		sim_time_type EraseReasonableSuspensionTimeForWrite,
+		bool EraseSuspensionEnabled, 
+		bool ProgramSuspensionEnabled)
 		: Sim_Object(id), ftl(ftl), _NVMController(NVMController), type(Type),
 		channel_count(ChannelCount), chip_no_per_channel(chip_no_per_channel), die_no_per_chip(DieNoPerChip), plane_no_per_die(PlaneNoPerDie),
 		eraseSuspensionEnabled(EraseSuspensionEnabled), programSuspensionEnabled(ProgramSuspensionEnabled),

--- a/src/ssd/TSU_Base.h
+++ b/src/ssd/TSU_Base.h
@@ -23,11 +23,11 @@ class TSU_Base : public MQSimEngine::Sim_Object
 {
 public:
 	TSU_Base(const sim_object_id_type &id, FTL *ftl, NVM_PHY_ONFI_NVDDR2 *NVMController, Flash_Scheduling_Type Type,
-			 unsigned int Channel_no, unsigned int chip_no_per_channel, unsigned int DieNoPerChip, unsigned int PlaneNoPerDie,
-			 bool EraseSuspensionEnabled, bool ProgramSuspensionEnabled,
+			 unsigned int Channel_no, unsigned int chip_no_per_channel, unsigned int DieNoPerChip, unsigned int PlaneNoPerDie,			 
 			 sim_time_type WriteReasonableSuspensionTimeForRead,
 			 sim_time_type EraseReasonableSuspensionTimeForRead,
-			 sim_time_type EraseReasonableSuspensionTimeForWrite);
+			 sim_time_type EraseReasonableSuspensionTimeForWrite,
+			 bool EraseSuspensionEnabled, bool ProgramSuspensionEnabled);
 	virtual ~TSU_Base();
 	void Setup_triggers();
 

--- a/src/ssd/TSU_Priority_OutOfOrder.cpp
+++ b/src/ssd/TSU_Priority_OutOfOrder.cpp
@@ -406,6 +406,9 @@ bool TSU_Priority_OutOfOrder::service_read_transaction(NVM::FlashMemory::Flash_C
     case ChipStatus::IDLE:
         break;
     case ChipStatus::WRITING:
+        if (_NVMController->CheckSuspendLock(chip))
+            return false;
+
         if (!programSuspensionEnabled || _NVMController->HasSuspendedCommand(chip))
         {
             return false;
@@ -415,7 +418,11 @@ bool TSU_Priority_OutOfOrder::service_read_transaction(NVM::FlashMemory::Flash_C
             return false;
         }
         suspensionRequired = true;
+        break;
     case ChipStatus::ERASING:
+        if (_NVMController->CheckSuspendLock(chip))
+            return false;
+
         if (!eraseSuspensionEnabled || _NVMController->HasSuspendedCommand(chip))
         {
             return false;
@@ -425,6 +432,7 @@ bool TSU_Priority_OutOfOrder::service_read_transaction(NVM::FlashMemory::Flash_C
             return false;
         }
         suspensionRequired = true;
+        break;
     default:
         return false;
     }


### PR DESCRIPTION
Thanks to the author. It is a great SSD simulator. 

But in the latest version, the Program Suspend does not work.
It seems that the author blocked it because there were a lot of problems.

I fixed some hidden problems, and it works well again.

There are three major issues.
1. The suspend-related parameter was not loaded because there is a typo in the XML parsing code
2. TSU class initialize parameter order is twisted
3. If the read is performed in the suspended program completion path, try to suspend again with an abnormal internal state.

Correction of problems 1 and 2 was simple.
To solve problem 3, I created a Suspend Lock that prevents retrying the suspend before the previous suspend is complete.

As a result, it was confirmed that Program Suspend was performed well.